### PR TITLE
Bump to v3.1.0

### DIFF
--- a/io.gpt4all.gpt4all.yml
+++ b/io.gpt4all.gpt4all.yml
@@ -162,8 +162,8 @@ modules:
     sources:
       - type: git
         url: https://github.com/nomic-ai/gpt4all.git
-        tag: v3.0.0
-        commit: 4c26726f3e27dcf9b6e47faecd7bc005d0d918e2
+        tag: v3.1.0
+        commit: 03d460c7321bddea25df6988713f01c447d9e0b5
       - type: file
         url: https://gpt4all.io/models/gguf/nomic-embed-text-v1.5.f16.gguf
         md5: a5401e7f7e46ed9fcaed5b60a281d547

--- a/patches/0002-appdata-version.patch
+++ b/patches/0002-appdata-version.patch
@@ -7,7 +7,7 @@ index ce413195..7a7ac795 100644
      <url type="vcs-browser">https://github.com/nomic-ai/gpt4all</url>
      <releases>
 -      <release version="2.7.5" date="2024-05-03"></release>              
-+      <release version="3.0.0" date="2024-07-02"></release>              
++      <release version="3.1.0" date="2024-07-02"></release>              
      </releases>
      <launchable type="desktop-id">io.gpt4all.gpt4all.desktop</launchable>
      <content_rating type="oars-1.1">

--- a/patches/0002-appdata-version.patch
+++ b/patches/0002-appdata-version.patch
@@ -7,7 +7,7 @@ index ce413195..7a7ac795 100644
      <url type="vcs-browser">https://github.com/nomic-ai/gpt4all</url>
      <releases>
 -      <release version="2.7.5" date="2024-05-03"></release>              
-+      <release version="3.1.0" date="2024-07-02"></release>              
++      <release version="3.1.0" date="2024-07-24"></release>              
      </releases>
      <launchable type="desktop-id">io.gpt4all.gpt4all.desktop</launchable>
      <content_rating type="oars-1.1">


### PR DESCRIPTION
## Latest News

* **New Model Support**: LLaMa 3.1 8b, Gemma, Mixtral, GPT-NeoX, Gemma 2, OpenELM, ChatGLM, Jais architectures, StarCoder2, XVERSE, Command R, and OLMo (all with Vulkan support)
* **Suggested Follow Up Questions**: Get follow up questions on your LocalDocs or chats automatically suggested

With the introduction of LLaMa 8b 3.1, we can now enable tool calling (e.g. internet searches, code interpreter) in GPT4All. We are working to investigate the feasibility of this feature!

<https://github.com/nomic-ai/gpt4all/blob/dbe953254a6da90d8ab85ec630bd9089054c2a42/gpt4all-chat/metadata/latestnews.md>